### PR TITLE
Replace isNullOrEmpty with null/empty check

### DIFF
--- a/src/main/kotlin/com/github/shiraji/databindinglayout/linemaker/KtLayoutNavigationLineMarkerProvider.kt
+++ b/src/main/kotlin/com/github/shiraji/databindinglayout/linemaker/KtLayoutNavigationLineMarkerProvider.kt
@@ -7,7 +7,6 @@ import com.intellij.codeInsight.daemon.LineMarkerProvider
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.editor.markup.GutterIconRenderer
 import com.intellij.psi.PsiElement
-import com.intellij.util.containers.isNullOrEmpty
 import org.jetbrains.kotlin.psi.KtClass
 
 class KtLayoutNavigationLineMarkerProvider : LineMarkerProvider {
@@ -15,7 +14,8 @@ class KtLayoutNavigationLineMarkerProvider : LineMarkerProvider {
     override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? {
         val ktClass = element as? KtClass ?: return null
         val qualifiedName = ktClass.fqName.toString()
-        if (collectLayoutVariableTypesOf(ktClass.project, qualifiedName).isNullOrEmpty()) return null
+        val layoutVariables = collectLayoutVariableTypesOf(ktClass.project, qualifiedName)
+        if (layoutVariables == null || layoutVariables.isEmpty()) return null
         return LineMarkerInfo<PsiElement>(ktClass, ktClass.nameIdentifier!!.textRange, AllIcons.FileTypes.Xml, Pass.UPDATE_ALL, null, LayoutIconNavigationHandler(qualifiedName), GutterIconRenderer.Alignment.LEFT)
     }
 

--- a/src/main/kotlin/com/github/shiraji/databindinglayout/linemaker/LayoutIconNavigationHandler.kt
+++ b/src/main/kotlin/com/github/shiraji/databindinglayout/linemaker/LayoutIconNavigationHandler.kt
@@ -11,14 +11,13 @@ import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.psi.PsiElement
 import com.intellij.psi.impl.source.xml.XmlTagImpl
 import com.intellij.psi.xml.XmlAttribute
-import com.intellij.util.containers.isNullOrEmpty
 import java.awt.event.MouseEvent
 
 class LayoutIconNavigationHandler(val qualifiedName: String) : GutterIconNavigationHandler<PsiElement> {
     override fun navigate(mouseEvent: MouseEvent?, psiElement: PsiElement?) {
         psiElement ?: return
         val types = collectLayoutVariableTypesOf(psiElement.project, qualifiedName)
-        if (types == null || types.isNullOrEmpty()) return
+        if (types == null || types.isEmpty()) return
         when (types.size) {
             0 -> return
             1 -> jumpToLayout(types.first())

--- a/src/main/kotlin/com/github/shiraji/databindinglayout/linemaker/LayoutNavigationLineMarkerProvider.kt
+++ b/src/main/kotlin/com/github/shiraji/databindinglayout/linemaker/LayoutNavigationLineMarkerProvider.kt
@@ -8,14 +8,14 @@ import com.intellij.icons.AllIcons
 import com.intellij.openapi.editor.markup.GutterIconRenderer
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
-import com.intellij.util.containers.isNullOrEmpty
 
 class LayoutNavigationLineMarkerProvider : LineMarkerProvider {
 
     override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? {
         val psiClass = element as? PsiClass ?: return null
         val qualifiedName = psiClass.qualifiedName ?: return null
-        if (collectLayoutVariableTypesOf(psiClass.project, qualifiedName).isNullOrEmpty()) return null
+        val layoutVariableTypes = collectLayoutVariableTypesOf(psiClass.project, qualifiedName)
+        if (layoutVariableTypes == null || layoutVariableTypes.isEmpty()) return null
         return LineMarkerInfo<PsiElement>(psiClass, psiClass.nameIdentifier!!.textRange, AllIcons.FileTypes.Xml, Pass.UPDATE_ALL, null, LayoutIconNavigationHandler(qualifiedName), GutterIconRenderer.Alignment.LEFT)
     }
 


### PR DESCRIPTION
I still think this is the problem with Kotlin plugin. However, even
Kotlin 1.1.1 and 1.1.2 plugin has the NoSuchMethodError, it's time to
remove the method.

Close #35 
Close #44 